### PR TITLE
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ A Google Compute Engine Interface For Cloudstack
 
 .. image:: https://badge.fury.io/py/gstack.png
        :target: https://pypi.python.org/pypi/gstack
-.. image:: https://api.travis-ci.org/apache/cloudstack-gcestack.png?branch=master
+.. image:: https://api.travis-ci.org/apache/cloudstack-gcestack.png?branch=main
        :target: https://travis-ci.org/apache/cloudstack-gcestack
 
 Description

--- a/pylint.rc
+++ b/pylint.rc
@@ -10,7 +10,7 @@
 # Profiled execution.
 profile=no
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=CVS
 


### PR DESCRIPTION
Inclusivity changes for CloudStack - rename some offensive words/terms as appropriate, that are meaningful and inclusive.

- Renamed default git branch name from 'master' to 'main'.

- Replaced whitelist and blacklist with allowlist and denylist respectively.